### PR TITLE
Fix CI/CD: Build Groovy JAR locally instead of downloading from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
       run: |
         ./gradlew build -x test
     
+    - name: Copy Groovy JAR for Spring Boot build
+      run: |
+        mkdir -p src/java/cron-query-service/lib
+        cp build/libs/cron-query-groovy-*.jar src/java/cron-query-service/lib/
+    
     - name: Build Spring Boot JAR
       working-directory: src/java/cron-query-service
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,9 +132,16 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     
-    - name: Download Groovy JAR dependency
-      working-directory: src/java/cron-query-service
-      run: mvn initialize
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    
+    - name: Build Groovy JAR
+      run: ./gradlew build -x test
+    
+    - name: Copy Groovy JAR for Spring Boot
+      run: |
+        mkdir -p src/java/cron-query-service/lib
+        cp build/libs/cron-query-groovy-*.jar src/java/cron-query-service/lib/
         
     - name: Run Maven tests
       working-directory: src/java/cron-query-service
@@ -167,9 +174,16 @@ jobs:
         distribution: 'temurin'
         cache: 'maven'
     
-    - name: Download Groovy JAR dependency
-      working-directory: src/java/cron-query-service
-      run: mvn initialize
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    
+    - name: Build Groovy JAR
+      run: ./gradlew build -x test
+    
+    - name: Copy Groovy JAR for Spring Boot
+      run: |
+        mkdir -p src/java/cron-query-service/lib
+        cp build/libs/cron-query-groovy-*.jar src/java/cron-query-service/lib/
         
     - name: Build and run integration tests
       working-directory: src/java/cron-query-service

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,10 +48,12 @@ test_groovy:
 # Spring Boot microservice tests (Linux)
 test_spring_boot:
   stage: test
-  image: maven:3.9-eclipse-temurin-21
+  image: eclipse-temurin:21-jdk
   script:
+    - ./gradlew build -x test
+    - mkdir -p src/java/cron-query-service/lib
+    - cp build/libs/cron-query-groovy-*.jar src/java/cron-query-service/lib/
     - cd src/java/cron-query-service
-    - mvn initialize
     - mvn test
   artifacts:
     reports:


### PR DESCRIPTION
The Spring Boot build was failing because it tried to download the Groovy JAR from a GitHub release that didn't exist yet (circular dependency).

Solution: Build the Groovy JAR in the same workflow, then copy it to the lib/ directory where Spring Boot expects it. This works for both test and release workflows.

Changes:
- GitHub test workflow: Build Groovy JAR before Spring Boot tests
- GitHub release workflow: Build Groovy JAR before Spring Boot build
- GitLab CI: Build Groovy JAR before Spring Boot tests