### PR TITLE
Fix GitLab Docker build: Build Groovy JAR before Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,8 +112,12 @@ build_docker:
   services:
     - docker:24-dind
   before_script:
+    - apk add --no-cache openjdk21
     - docker info
   script:
+    - ./gradlew build -x test
+    - mkdir -p src/java/cron-query-service/lib
+    - cp build/libs/cron-query-groovy-*.jar src/java/cron-query-service/lib/
     - cd src/java/cron-query-service
     - docker build -t cron-query-service:${CI_COMMIT_TAG#v} .
     - docker save cron-query-service:${CI_COMMIT_TAG#v} -o ../../../cron-query-service-docker.tar


### PR DESCRIPTION
The build_docker job was failing because the lib/ directory with the Groovy JAR didn't exist. Build the Groovy JAR first and copy it to lib/ before building the Docker image.